### PR TITLE
Update README example for PostgreSQL syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,12 @@ wait4x mysql username:password@unix(/tmp/mysql.sock)/myDatabase
 
 ```shell
 # Checking PostgreSQL TCP connection
-wait4x postgresql 'postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full'
+wait4x postgresql 'postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=disable'
 
 # Checking PostgreSQL Unix socket connection
 wait4x postgresql 'postgres://bob:secret@/mydb?host=/var/run/postgresql'
 ```
+Syntax for the database URL: https://pkg.go.dev/github.com/lib/pq
 
 ### InfluxDB
 


### PR DESCRIPTION
It took me some time to find why postgresql checking was not working for me.
It turned out that, by default, the underlying library requires SSL to be configured on the PostgreSQL server (which was not my case).

So I suggest to disable SSL checking in this example (like it's done for MySQL), and provide a link to the complete syntax