### PR TITLE
Add tzdata package in Docker image, to be able to set timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ FROM scratch AS artifact
 COPY --from=releaser /out /
 
 FROM alpine:3.15
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates tzdata
 
 COPY --from=binary /wait4x /usr/bin/wait4x
 


### PR DESCRIPTION
Fixes #100

Tested only on linux/amd64 platform:

```
$ docker run wait4x:2.8.0-mossroy tcp localhost:8080
2022-10-18T07:46:45Z INF [TCP] Checking the localhost:8080 ...
2022-10-18T07:46:46Z INF [TCP] Checking the localhost:8080 ...
2022-10-18T07:46:47Z INF [TCP] Checking the localhost:8080 ...
^CError: context canceled
$ docker run -e TZ=Europe/Paris wait4x:2.8.0-mossroy tcp localhost:8080
2022-10-18T09:46:51+02:00 INF [TCP] Checking the localhost:8080 ...
2022-10-18T09:46:52+02:00 INF [TCP] Checking the localhost:8080 ...
^C2022-10-18T09:46:53+02:00 INF [TCP] Checking the localhost:8080 ...
Error: context canceled
```