### PR TITLE
add .exe file extension for windows builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ FROM base AS build
 ARG TARGETPLATFORM
 
 RUN --mount=type=bind,target=/src,rw \
-  --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/go/pkg/mod \
-  GO_BINARY=xx-go WAIT4X_BUILD_OUTPUT=/usr/bin make build \
-  && xx-verify --static /usr/bin/wait4x
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    GO_BINARY=xx-go WAIT4X_BUILD_OUTPUT=/usr/bin make build \
+    && xx-verify --static /usr/bin/wait4x
 
 FROM scratch AS binary
 COPY --from=build /usr/bin/wait4x /
@@ -30,7 +30,6 @@ RUN --mount=from=binary,target=/build \
   --mount=type=bind,target=/src \
   mkdir -p /out \
   && cp /build/wait4x /src/README.md /src/LICENSE . \
-  && if [$TARGETOS = "windows/amd64" ] || [$TARGETOS = "windows/arm64" ] then mv wait4x wait4x.exe fi \
   && tar -czvf "/out/wait4x-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}.tar.gz" * \
   # Change dir to "/out" to prevent adding "/out" in the sha256sum command output.
   && cd /out \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ FROM base AS build
 ARG TARGETPLATFORM
 
 RUN --mount=type=bind,target=/src,rw \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    GO_BINARY=xx-go WAIT4X_BUILD_OUTPUT=/usr/bin make build \
-    && xx-verify --static /usr/bin/wait4x
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg/mod \
+  GO_BINARY=xx-go WAIT4X_BUILD_OUTPUT=/usr/bin make build \
+  && xx-verify --static /usr/bin/wait4x
 
 FROM scratch AS binary
 COPY --from=build /usr/bin/wait4x /
@@ -30,6 +30,7 @@ RUN --mount=from=binary,target=/build \
   --mount=type=bind,target=/src \
   mkdir -p /out \
   && cp /build/wait4x /src/README.md /src/LICENSE . \
+  && if [$TARGETOS = "windows/amd64" ] || [$TARGETOS = "windows/arm64" ] then mv wait4x wait4x.exe fi \
   && tar -czvf "/out/wait4x-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}.tar.gz" * \
   # Change dir to "/out" to prevent adding "/out" in the sha256sum command output.
   && cd /out \

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ check-revive:
 	revive -config .revive.toml -formatter friendly ./...
 
 build:
+	@ if [$(GOOS) = "windows" ]then $(WAIT4X_BINARY_NAME)=$(WAIT4X_BINARY_NAME).exe fi
 	$(GO_ENVIRONMENTS) $(GO_BINARY) build -v $(WAIT4X_BUILD_FLAGS) -o $(WAIT4X_BUILD_OUTPUT)/$(WAIT4X_BINARY_NAME) cmd/wait4x/main.go
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GO_ENVIRONMENTS ?=
 # Wait4X output name
 WAIT4X_BINARY_NAME ?= wait4x
 ifeq ($(GOOS), "windows")
-WAIT4X_BINARY_NAME=$(WAIT4X_BINARY_NAME).exe
+WAIT4X_BINARY_NAME ?= ${WAIT4X_BINARY_NAME}.exe
 endif
 
 # build output path

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ GO_ENVIRONMENTS ?=
 
 # Wait4X output name
 WAIT4X_BINARY_NAME ?= wait4x
+ifeq ($(GOOS), "windows")
+WAIT4X_BINARY_NAME=$(WAIT4X_BINARY_NAME).exe
+endif
 
 # build output path
 WAIT4X_BUILD_OUTPUT ?= ${CURDIR}/dist
@@ -85,7 +88,6 @@ check-revive:
 	revive -config .revive.toml -formatter friendly ./...
 
 build:
-	@ if [$(GOOS) = "windows" ]then $(WAIT4X_BINARY_NAME)=$(WAIT4X_BINARY_NAME).exe fi
 	$(GO_ENVIRONMENTS) $(GO_BINARY) build -v $(WAIT4X_BUILD_FLAGS) -o $(WAIT4X_BUILD_OUTPUT)/$(WAIT4X_BINARY_NAME) cmd/wait4x/main.go
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ GO_ENVIRONMENTS ?=
 
 # Wait4X output name
 WAIT4X_BINARY_NAME ?= wait4x
-ifeq ($(GOOS), "windows")
-WAIT4X_BINARY_NAME ?= ${WAIT4X_BINARY_NAME}.exe
+ifeq ($(GOOS),windows)
+WAIT4X_BINARY_NAME := ${WAIT4X_BINARY_NAME}.exe
 endif
 
 # build output path

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ GO_ENVIRONMENTS ?=
 
 # Wait4X output name
 WAIT4X_BINARY_NAME ?= wait4x
+
+# Change output to .exe for windows
+GOOS ?= $(shell go env GOOS)
 ifeq ($(GOOS),windows)
 WAIT4X_BINARY_NAME := ${WAIT4X_BINARY_NAME}.exe
 endif

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ GO_ENVIRONMENTS ?=
 WAIT4X_BINARY_NAME ?= wait4x
 
 # Change output to .exe for windows
-GOOS ?= $(shell go env GOOS)
-ifeq ($(GOOS),windows)
+ifeq (windows,$(filter windows,$(shell go env GOOS) $(TARGETOS)))
 WAIT4X_BINARY_NAME := ${WAIT4X_BINARY_NAME}.exe
 endif
 


### PR DESCRIPTION
This PR adresses #105 and renames windows binaries to `wait4x.exe` instead of `wait4x`