### PR TITLE
Add Exponential Backoff Checking to Wait4X

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ interval time.
     - Temporal
 - **Reverse Checking:** Invert the sense of checking to find a free port or non-ready services
 - **Parallel Checking**: You can define multiple inputs to be checked
+- **Exponential Backoff Checking**: Retry using an exponential backoff approach to improve efficiency and reduce errors.
 - **CI/CD Friendly:** Well-suited to be part of a CI/CD pipeline step
 - **Cross Platform:** One single pre-built binary for Linux, Mac OSX, and Windows
 - **Importable:** Beside the CLI tool, Wait4X can be imported as a pkg in your Go app
@@ -177,6 +178,9 @@ wait4x http https://www.kernel.org/ --expect-body-xpath "//*[@id="tux-gear"]"
 
 # Request headers:
 wait4x http https://ifconfig.co --request-header "Content-Type: application/json" --request-header "Authorization: Token 123"
+
+# Enable exponential backoff retry
+wait4x http https://ifconfig.co --expect-status-code 200 --backoff-policy exponential  --backoff-exponential-max-interval 120s --timeout 120s
 ```
 
 ### Redis

--- a/internal/app/wait4x/cmd/influxdb.go
+++ b/internal/app/wait4x/cmd/influxdb.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/influxdb"
@@ -48,6 +49,9 @@ func runInfluxDB(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	// ArgsLenAtDash returns -1 when -- was not specified
 	if i := cmd.ArgsLenAtDash(); i != -1 {
@@ -68,6 +72,9 @@ func runInfluxDB(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/mongodb.go
+++ b/internal/app/wait4x/cmd/mongodb.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/mongodb"
@@ -51,6 +52,9 @@ func runMongoDB(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	// ArgsLenAtDash returns -1 when -- was not specified
 	if i := cmd.ArgsLenAtDash(); i != -1 {
@@ -71,6 +75,9 @@ func runMongoDB(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/mysql.go
+++ b/internal/app/wait4x/cmd/mysql.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/mysql"
@@ -51,6 +52,9 @@ func runMysql(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	// ArgsLenAtDash returns -1 when -- was not specified
 	if i := cmd.ArgsLenAtDash(); i != -1 {
@@ -71,6 +75,9 @@ func runMysql(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/postgresql.go
+++ b/internal/app/wait4x/cmd/postgresql.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/postgresql"
@@ -49,6 +50,9 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	// ArgsLenAtDash returns -1 when -- was not specified
 	if i := cmd.ArgsLenAtDash(); i != -1 {
@@ -69,6 +73,9 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/rabbitmq.go
+++ b/internal/app/wait4x/cmd/rabbitmq.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/rabbitmq"
@@ -54,6 +55,9 @@ func runRabbitMQ(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	conTimeout, _ := cmd.Flags().GetDuration("connection-timeout")
 	insecureSkipTLSVerify, _ := cmd.Flags().GetBool("insecure-skip-tls-verify")
@@ -81,6 +85,9 @@ func runRabbitMQ(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/redis.go
+++ b/internal/app/wait4x/cmd/redis.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/redis"
@@ -63,6 +64,9 @@ func runRedis(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	conTimeout, _ := cmd.Flags().GetDuration("connection-timeout")
 	expectKey, _ := cmd.Flags().GetString("expect-key")
@@ -90,6 +94,9 @@ func runRedis(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/tcp.go
+++ b/internal/app/wait4x/cmd/tcp.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"errors"
+
 	"github.com/spf13/cobra"
 	"wait4x.dev/v2/checker"
 	"wait4x.dev/v2/checker/tcp"
@@ -50,6 +51,9 @@ func runTCP(cmd *cobra.Command, args []string) error {
 	interval, _ := cmd.Flags().GetDuration("interval")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	invertCheck, _ := cmd.Flags().GetBool("invert-check")
+	backoffPoclicy, _ := cmd.Flags().GetString("backoff-policy")
+	backoffExpMaxInterval, _ := cmd.Flags().GetDuration("backoff-exponential-max-interval")
+	backoffCoefficient, _ := cmd.Flags().GetFloat64("backoff-exponential-coefficient")
 
 	conTimeout, _ := cmd.Flags().GetDuration("connection-timeout")
 
@@ -72,6 +76,9 @@ func runTCP(cmd *cobra.Command, args []string) error {
 		checkers,
 		waiter.WithTimeout(timeout),
 		waiter.WithInterval(interval),
+		waiter.WithBackoffCoefficient(backoffCoefficient),
+		waiter.WithBackoffPolicy(backoffPoclicy),
+		waiter.WithBackoffExponentialMaxInterval(backoffExpMaxInterval),
 		waiter.WithInvertCheck(invertCheck),
 		waiter.WithLogger(Logger),
 	)

--- a/internal/app/wait4x/cmd/utils.go
+++ b/internal/app/wait4x/cmd/utils.go
@@ -1,0 +1,25 @@
+// Copyright 2023 The Wait4X Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/waiter/utils.go
+++ b/waiter/utils.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The Wait4X Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package waiter
+
+import (
+	"math"
+	"time"
+)
+
+func exponentialBackoff(retries int, backoffCoefficient float64, initialInterval, maxInterval time.Duration) time.Duration {
+	interval := initialInterval * time.Duration(math.Pow(backoffCoefficient, float64(retries)))
+	if interval > maxInterval {
+		return maxInterval
+	}
+	return interval
+}

--- a/waiter/waiter.go
+++ b/waiter/waiter.go
@@ -18,11 +18,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/go-logr/logr"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/go-logr/logr"
 	"wait4x.dev/v2/checker"
+)
+
+const (
+	BackoffPolicyLinear      = "linear"
+	BackoffPolicyExponential = "exponential"
 )
 
 // Check represents the checker's check method.
@@ -33,10 +39,13 @@ type Option func(s *options)
 
 // options represents waiter options
 type options struct {
-	timeout     time.Duration
-	interval    time.Duration
-	invertCheck bool
-	logger      logr.Logger
+	timeout                       time.Duration
+	interval                      time.Duration
+	invertCheck                   bool
+	logger                        logr.Logger
+	backoffPolicy                 string
+	backoffExponentialMaxInterval time.Duration
+	backoffCoefficient            float64
 }
 
 // WithTimeout configures a time limit for whole of checking
@@ -64,6 +73,28 @@ func WithInvertCheck(invertCheck bool) Option {
 func WithLogger(logger logr.Logger) Option {
 	return func(o *options) {
 		o.logger = logger
+	}
+}
+
+// WithBackoffPolicy returns an Option that sets the backoff policy for retries
+func WithBackoffPolicy(backoffPolicy string) Option {
+	return func(o *options) {
+		o.backoffPolicy = backoffPolicy
+	}
+}
+
+// WithBackoffExponentialMaxInterval is a function that returns an Option which sets the
+// maximum interval time duration of the exponential backoff algorithm.
+func WithBackoffExponentialMaxInterval(backoffExponentialMaxInterval time.Duration) Option {
+	return func(o *options) {
+		o.backoffExponentialMaxInterval = backoffExponentialMaxInterval
+	}
+}
+
+// WithBackoffCoefficient sets the backoffCoefficient for use in retry backoff calculations.
+func WithBackoffCoefficient(backoffCoefficient float64) Option {
+	return func(o *options) {
+		o.backoffCoefficient = backoffCoefficient
 	}
 }
 
@@ -124,10 +155,13 @@ func WaitWithContext(ctx context.Context, checker checker.Checker, opts ...Optio
 // WaitContext waits for end up of check execution.
 func WaitContext(ctx context.Context, chk checker.Checker, opts ...Option) error {
 	options := &options{
-		timeout:     10 * time.Second,
-		interval:    time.Second,
-		invertCheck: false,
-		logger:      logr.Discard(),
+		timeout:                       10 * time.Second,
+		interval:                      time.Second,
+		invertCheck:                   false,
+		logger:                        logr.Discard(),
+		backoffPolicy:                 BackoffPolicyLinear,
+		backoffExponentialMaxInterval: 5 * time.Second,
+		backoffCoefficient:            2.0,
 	}
 
 	// apply the list of options to waiter
@@ -154,6 +188,9 @@ func WaitContext(ctx context.Context, chk checker.Checker, opts ...Option) error
 		return err
 	}
 
+	//This is a counter for exponential backoff
+	retries := 0
+
 	for {
 		options.logger.Info(fmt.Sprintf("[%s] Checking the %s ...", chkName, chkID))
 
@@ -169,6 +206,15 @@ func WaitContext(ctx context.Context, chk checker.Checker, opts ...Option) error
 			}
 		}
 
+		var waitDuration time.Duration
+		if options.backoffPolicy == BackoffPolicyExponential {
+			waitDuration = exponentialBackoff(retries, options.backoffCoefficient, options.interval, options.backoffExponentialMaxInterval)
+		} else if options.backoffPolicy == BackoffPolicyLinear {
+			waitDuration = options.interval
+		} else {
+			return fmt.Errorf("invalid backoff policy: %s", options.backoffPolicy)
+		}
+
 		if options.invertCheck == true {
 			if err == nil {
 				goto CONTINUE
@@ -182,12 +228,13 @@ func WaitContext(ctx context.Context, chk checker.Checker, opts ...Option) error
 		}
 
 	CONTINUE:
-
+		retries++
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(options.interval):
+		case <-time.After(waitDuration):
 		}
+
 	}
 
 	return nil

--- a/waiter/waiter.go
+++ b/waiter/waiter.go
@@ -26,8 +26,11 @@ import (
 	"wait4x.dev/v2/checker"
 )
 
+// Constants representing the available backoff policies for retry mechanisms.
 const (
-	BackoffPolicyLinear      = "linear"
+	// BackoffPolicyLinear indicates a linear backoff policy,
+	BackoffPolicyLinear = "linear"
+	// BackoffPolicyExponential indicates an exponential backoff policy.
 	BackoffPolicyExponential = "exponential"
 )
 


### PR DESCRIPTION
### Description
This merge request introduces the Exponential Backoff Checking feature to Wait4X. The Exponential Backoff algorithm reduces the load on the system by incrementally increasing the waiting time between retries. In addition to this, the following changes were made:

- Added `--backoff-policy` flag to be able to change the backoff policy in the supported protocols (HTTP, InfluxDB, MongoDB, MySQL, PostgreSQL, RabbitMQ, Redis, TCP).
- Added `--backoff-exponential-max-interval` flag to set the maximum interval time between each loop when `--rbackoff-policy` is `exponential`.
- Updated the README.md to include documentation for this new feature.
- Some minor code adjustments to support the new feature.
