### PR TITLE
Create a flake for Nix derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685655444,
+        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Wait for a port or a service to enter the requested state.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }@inputs: flake-utils.lib.eachDefaultSystem (system: {
+    packages = let
+      inherit (nixpkgs) lib;
+      inherit (nixpkgs.legacyPackages.${system}) buildGoModule;
+    in {
+      default = buildGoModule {
+        pname = "wait4x";
+        version = builtins.substring 0 8 self.lastModifiedDate;
+
+        src = self;
+        # don't know why but nix is unhappy about vendorHash = null
+        vendorHash = "sha256-Jp2IUvkcqLcJk0a5A79SQTjqAkmIEVc9Ove3rMkkWuI=";
+
+        # Nix doesn't allow network access during tests, so belive in the existing tests
+        doCheck = false;
+      };
+    };
+  });
+}


### PR DESCRIPTION
A minimal addition, but should be working.

Golang tests can't be run since Nix sandbox disallows network access.

Otherwise tested haphazardly with `nix build` on my local machine.

😄 