### PR TITLE
feat: install bash in the alpine docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ FROM scratch AS artifact
 COPY --from=releaser /out /
 
 FROM alpine:3.17.1
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata bash
 
 COPY --from=binary /wait4x /usr/bin/wait4x
 


### PR DESCRIPTION
Alpine docker image doesn't have `bash` installed **by default**.  
In some cases, we want to use this image in k8s manifests where the `wait4x` is used in bash scripts. 
Currently, we can't do that and we only have shell scripting(`sh`).  

I've installed `bash` to make it easier for users like me to use `bash` scripting with image.