### PR TITLE
Hide passwords in error logs

### DIFF
--- a/checker/mysql/mysql.go
+++ b/checker/mysql/mysql.go
@@ -22,7 +22,10 @@ import (
 	"wait4x.dev/v2/checker"
 	// Needed for the MySQL driver
 	_ "github.com/go-sql-driver/mysql"
+	"regexp"
 )
+
+var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
 
 // MySQL represents MySQL checker
 type MySQL struct {
@@ -66,7 +69,7 @@ func (m *MySQL) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the mysql server", err,
-				"dsn", m.dsn,
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(m.dsn,`***:***@`),
 			)
 		}
 

--- a/checker/mysql/mysql.go
+++ b/checker/mysql/mysql.go
@@ -69,7 +69,7 @@ func (m *MySQL) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the mysql server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(m.dsn,`***:***@`),
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(m.dsn, `***:***@`),
 			)
 		}
 

--- a/checker/mysql/mysql.go
+++ b/checker/mysql/mysql.go
@@ -25,7 +25,7 @@ import (
 	"regexp"
 )
 
-var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
+var hidePasswordRegexp = regexp.MustCompile(`^([^:]+):[^:@]+@`)
 
 // MySQL represents MySQL checker
 type MySQL struct {
@@ -69,7 +69,7 @@ func (m *MySQL) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the mysql server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(m.dsn, `***:***@`),
+				"dsn", hidePasswordRegexp.ReplaceAllString(m.dsn, `$1:***@`),
 			)
 		}
 

--- a/checker/postgresql/postgresql.go
+++ b/checker/postgresql/postgresql.go
@@ -69,7 +69,7 @@ func (p *PostgreSQL) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the postgresql server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(p.dsn,`***:***@`),
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(p.dsn, `***:***@`),
 			)
 		}
 

--- a/checker/postgresql/postgresql.go
+++ b/checker/postgresql/postgresql.go
@@ -25,7 +25,7 @@ import (
 	"regexp"
 )
 
-var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
+var hidePasswordRegexp = regexp.MustCompile(`^(postgres://[^/:]+):[^:@]+@`)
 
 // PostgreSQL represents PostgreSQL checker
 type PostgreSQL struct {
@@ -69,7 +69,7 @@ func (p *PostgreSQL) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the postgresql server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(p.dsn, `***:***@`),
+				"dsn", hidePasswordRegexp.ReplaceAllString(p.dsn, `$1:***@`),
 			)
 		}
 

--- a/checker/postgresql/postgresql.go
+++ b/checker/postgresql/postgresql.go
@@ -22,7 +22,10 @@ import (
 	"wait4x.dev/v2/checker"
 	// Needed for the PostgreSQL driver
 	_ "github.com/lib/pq"
+	"regexp"
 )
+
+var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
 
 // PostgreSQL represents PostgreSQL checker
 type PostgreSQL struct {
@@ -66,7 +69,7 @@ func (p *PostgreSQL) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the postgresql server", err,
-				"dsn", p.dsn,
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(p.dsn,`***:***@`),
 			)
 		}
 

--- a/checker/rabbitmq/rabbitmq.go
+++ b/checker/rabbitmq/rabbitmq.go
@@ -25,7 +25,7 @@ import (
 	"wait4x.dev/v2/checker"
 )
 
-var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
+var hidePasswordRegexp = regexp.MustCompile(`(amqp://[^/:]+):[^:@]+@`)
 
 // Option configures a RabbitMQ.
 type Option func(r *RabbitMQ)
@@ -121,7 +121,7 @@ func (r *RabbitMQ) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the rabbitmq server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.dsn, `***:***@`),
+				"dsn", hidePasswordRegexp.ReplaceAllString(r.dsn, `$1:***@`),
 			)
 		}
 

--- a/checker/rabbitmq/rabbitmq.go
+++ b/checker/rabbitmq/rabbitmq.go
@@ -22,7 +22,10 @@ import (
 	"net"
 	"time"
 	"wait4x.dev/v2/checker"
+	"regexp"
 )
+
+var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
 
 // Option configures a RabbitMQ.
 type Option func(r *RabbitMQ)
@@ -118,7 +121,7 @@ func (r *RabbitMQ) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the rabbitmq server", err,
-				"dsn", r.dsn,
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.dsn,`***:***@`),
 			)
 		}
 

--- a/checker/rabbitmq/rabbitmq.go
+++ b/checker/rabbitmq/rabbitmq.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"github.com/streadway/amqp"
 	"net"
+	"regexp"
 	"time"
 	"wait4x.dev/v2/checker"
-	"regexp"
 )
 
 var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
@@ -121,7 +121,7 @@ func (r *RabbitMQ) Check(ctx context.Context) (err error) {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the rabbitmq server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.dsn,`***:***@`),
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.dsn, `***:***@`),
 			)
 		}
 

--- a/checker/redis/redis.go
+++ b/checker/redis/redis.go
@@ -24,7 +24,7 @@ import (
 	"wait4x.dev/v2/checker"
 )
 
-var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
+var hidePasswordRegexp = regexp.MustCompile(`([^/]+//[^/:]+):[^:@]+@`)
 
 // Option configures a Redis.
 type Option func(r *Redis)
@@ -96,7 +96,7 @@ func (r *Redis) Check(ctx context.Context) error {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the redis server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.address, `***:***@`),
+				"dsn", hidePasswordRegexp.ReplaceAllString(r.address, `$1:***@`),
 			)
 		}
 

--- a/checker/redis/redis.go
+++ b/checker/redis/redis.go
@@ -96,7 +96,7 @@ func (r *Redis) Check(ctx context.Context) error {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the redis server", err,
-				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.address,`***:***@`),
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.address, `***:***@`),
 			)
 		}
 

--- a/checker/redis/redis.go
+++ b/checker/redis/redis.go
@@ -24,6 +24,8 @@ import (
 	"wait4x.dev/v2/checker"
 )
 
+var removeUsernamePasswordRegex = regexp.MustCompile(`[^/:@]+:[^/:@]+@`)
+
 // Option configures a Redis.
 type Option func(r *Redis)
 
@@ -94,7 +96,7 @@ func (r *Redis) Check(ctx context.Context) error {
 		if checker.IsConnectionRefused(err) {
 			return checker.NewExpectedError(
 				"failed to establish a connection to the redis server", err,
-				"dsn", r.address,
+				"dsn", removeUsernamePasswordRegex.ReplaceAllString(r.address,`***:***@`),
 			)
 		}
 


### PR DESCRIPTION
This PR replaces passwords by `***` in error logs (for the ones I could see).

Fixes #177 