### PR TITLE
feat: add opt-in h2c support for the http checker

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -121,6 +121,7 @@ func NewHTTPCommand() *cobra.Command {
 		String("cert-file", "", "Utilize this SSL certificate file to identify the HTTPS client.")
 	httpCommand.Flags().
 		String("key-file", "", "Utilize this SSL key file to identify the HTTPS client.")
+	httpCommand.Flags().Bool("h2c", false, "Enable HTTP/2 cleartext (h2c) for http:// URLs.")
 
 	return httpCommand
 }
@@ -139,6 +140,7 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 	caFile, _ := cmd.Flags().GetString("ca-file")
 	certFile, _ := cmd.Flags().GetString("cert-file")
 	keyFile, _ := cmd.Flags().GetString("key-file")
+	h2c, _ := cmd.Flags().GetBool("h2c")
 
 	logger, err := logr.FromContext(cmd.Context())
 	if err != nil {
@@ -193,6 +195,7 @@ func runHTTP(cmd *cobra.Command, args []string) error {
 			http.WithCAFile(caFile),
 			http.WithCertFile(certFile),
 			http.WithKeyFile(keyFile),
+			http.WithH2C(h2c),
 		)
 	}
 


### PR DESCRIPTION
This PR enables optional **h2c** for `http://` URLs while keeping current behavior unchanged by default.

**What’s included**
- `WithH2C(bool)` option and `--h2c` flag to opt into h2c.
- Uses `http2.Transport{AllowHTTP:true}` for cleartext HTTP only when:
  - h2c is enabled,
  - the URL scheme is `http`,
  - no HTTP proxy is configured, and
  - `--no-redirect` is set (avoids cross-scheme redirect issues).
- Default behavior preserved: HTTPS negotiates h2 via ALPN; HTTP remains HTTP/1.1 when h2c is off.
- Coverage added both at checker level and via the CLI path to verify end-to-end h2c.

**Why**
- Some local/dev/sidecar endpoints speak h2c; this makes Wait4X compatible without impacting existing users.